### PR TITLE
add all eth txns support

### DIFF
--- a/src/adapters/Ethereum.ts
+++ b/src/adapters/Ethereum.ts
@@ -1,16 +1,9 @@
 import { ActionAdapter } from "@dialectlabs/blinks";
-import { parseEther } from "viem";
 
 export class EthereumAdapter implements ActionAdapter {
   async signTransaction(
     tx: string
   ): Promise<{ signature: string } | { error: string }> {
-    const transaction = JSON.parse(tx);
-    const transactionParameters = {
-      to: transaction.to,
-      value: parseEther(transaction.value).toString(16), // Convert to hex
-    };
-
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         reject(new Error("Transaction signing timed out"));
@@ -33,7 +26,7 @@ export class EthereumAdapter implements ActionAdapter {
       window.postMessage(
         {
           type: "SIGN_TRANSACTION_ETHEREUM",
-          transaction: JSON.stringify(transactionParameters),
+          transaction: tx,
         },
         "*"
       );

--- a/src/pageScript.js
+++ b/src/pageScript.js
@@ -1,4 +1,5 @@
 import { VersionedTransaction } from "@solana/web3.js";
+import { parseTransaction } from 'viem';
 
 // Wallet connection handlers
 const walletHandlers = {
@@ -12,12 +13,15 @@ const walletHandlers = {
       });
       return accounts[0];
     },
-    sign: async (transaction, address) => {
+    sign: async (serializedTx) => {
+      const tx = parseTransaction(serializedTx);
       const transactionParameters = {
-        to: transaction.to,
-        from: address,
-        value: transaction.value,
+        from: connectedAddress,
+        to: tx.to,
+        value: tx.value,
+        data: tx.data,
       };
+  
       return window.ethereum.request({
         method: "eth_sendTransaction",
         params: [transactionParameters],
@@ -55,8 +59,7 @@ const messageHandlers = {
     if (!connectedAddress) {
       connectedAddress = await walletHandlers.ethereum.connect();
     }
-    const transaction = JSON.parse(data.transaction);
-    const txHash = await walletHandlers.ethereum.sign(transaction, connectedAddress);
+    const txHash = await walletHandlers.ethereum.sign(data.transaction);
     return { type: "TRANSACTION_SIGNED", txHash };
   },
   SIGN_TRANSACTION_SOLANA: async (data) => {


### PR DESCRIPTION
The extension currently supports only ETH transfers. This PR adds support for all Ethereum transactions.